### PR TITLE
Fix per i link target blank nel menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # PIANO TRIENNALE PER L’INFORMATICA NELLA PUBBLICA AMMINISTRAZIONE 2017 - 2019
 Questo repository contiene il codice sorgente del sito tematico relativo al *Piano Triennale per l'informatica nella pubblica amministrazione*.
-Il sito è sviluppato con Jekyll. Per configurare un ambiente di sviluppo è sufficiente eseguire i seguenti comandi:
+Il sito è sviluppato con Jekyll.
+
+Prerequisiti: ruby, ruby-dev e ruby-bundler; istruzione per una distribuzione linux Ubuntu:
+
+- `apt-get install ruby-bundler`
+- `apt-get install ruby-dev`
+
+Per configurare un ambiente di sviluppo è sufficiente eseguire i seguenti comandi nella directory principale del progetto:
 
     $ bundle install
     $ bundle exec jekyll serve

--- a/_data/network_links.yml
+++ b/_data/network_links.yml
@@ -17,9 +17,12 @@ forum:
   title: header_link_forum
   url: 'https://forum.italia.it/'
   li_markup_pre: '<span class="u-block u-padding-all-s u-margin-top-xs u-color-grey-50">GLI STRUMENTI</span>'
+  external: true
 docs:
   title: header_link_docs
   url: 'https://docs.developers.italia.it/'
+  external: true
 github:
   title: header_link_github
   url: 'https://github.com/italia/'
+  external: true

--- a/_includes/slim_header.html
+++ b/_includes/slim_header.html
@@ -4,7 +4,7 @@
     {% for link in site.data.network_links %}
       {% assign link_name = link[1].title %}
       <li class="{{ link[1].class }}" {% if link[1].upcoming %} style="color: white; opacity: 0.5;" {% endif %}>
-        {% unless link[1].upcoming %}<a class="u-color-white" href="{{ link[1].url }}" target="_blank">{% endunless %}
+        {% unless link[1].upcoming %}<a class="u-color-white" href="{{ link[1].url }}" {% if link[1].external %}target="_blank"{% endif %}>{% endunless %}
           {{ t[link_name] | default: link_name }}
         {% unless link[1].upcoming %}</a>{% endunless %}
       </li>


### PR DESCRIPTION
I link nel menu di navigazione principale (`slim_menu`) aprono tutti in target blank, perfino la home page stessa.

L'uso del target blank dovrebbe essere ormai abolito comunque, ma visto che qualcuno ancora "ci tiene" ho fatto in modo di rendere i link configurabili tramite la nuova chiave `external` nel file di configurazione `_data/network_links.yml`