### PR TITLE
chore: remove cookiebar

### DIFF
--- a/_data/l10n.yml
+++ b/_data/l10n.yml
@@ -3,9 +3,6 @@ it:
   name: italiano
   t:
     active_lang: lingua attiva
-    cookiebar_accept: Accetto
-    cookiebar_msg: Questo sito utilizza cookie tecnici, analytics e di terze parti. Proseguendo nella navigazione accetti l’utilizzo dei cookie.
-    cookiebar_privacy_policy: Privacy policy
     follow_us: seguici su
     header_link_pt: Piano Triennale
     header_link_developers: Developers
@@ -255,9 +252,6 @@ en:
   name: english
   t:
     active_lang: active language
-    cookiebar_accept: I accept
-    cookiebar_msg: This site uses technical cookies, analytics and third-party cookies. By continuing to browse, you accept the use of cookies.
-    cookiebar_privacy_policy: Privacy Policy
     follow_us: Follow us on
     header_link_pt: The Three-Year Plan
     header_link_developers: Developers

--- a/_includes/cookiebar.html
+++ b/_includes/cookiebar.html
@@ -1,9 +1,0 @@
-<div id="cookie-bar" class="CookieBar js-CookieBar u-background-95 u-padding-r-all" aria-hidden="true">
-  <p class="u-color-white u-text-r-xs u-lineHeight-m u-padding-r-bottom">
-    {{ t.cookiebar_msg }}<br>
-  </p>
-  <p>
-    <button class="Button Button--default u-text-r-xxs js-cookieBarAccept u-inlineBlock u-margin-r-all">{{ t.cookiebar_accept }}</button>
-    <a href="{{ site.privacy_link }}" class="u-text-r-xs u-color-teal-50">{{ t.cookiebar_privacy_policy }}</a>
-  </p>
-</div>

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -17,10 +17,6 @@
           ga("set", "anonymizeIp", true);
           ga('send', 'pageview');
       };
-      if ($.cookieBar && $.cookieBar.isAccepted()) {
-          sendGaPageview();
-      } else {
-          $(document).on('accept.cookiebar', sendGaPageview);
-      }
+      sendGaPageview();
   });
 </script>

--- a/_includes/piwik.html
+++ b/_includes/piwik.html
@@ -11,11 +11,7 @@
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
     }
-    if ($.cookieBar && $.cookieBar.isAccepted()) {
-        startPiwik();
-    } else {
-      $(document).on('accept.cookiebar', startPiwik);
-    }
+    startPiwik();
   });
 </script>
 <!-- End Piwik Code -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,8 +3,6 @@
 {% include head.html %}
 {% include skiplinks.html %}
 
-{% include cookiebar.html %}
-
 {% assign buttonLink = site.data.ext_links[page.lang].piano-triennale-index.rtd %}
 
 <div class="u-layout-wide u-layoutCenter u-posRelative">


### PR DESCRIPTION
The cookie bar is not needed for our use of cookies (see
https://www.garanteprivacy.it/web/guest/home/docweb/-/docweb-display/docweb/9677876).